### PR TITLE
Add node.js as execjs dependency on Rails 4+

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,3 +10,4 @@ apt_repository("node.js") do
   keyserver "keyserver.ubuntu.com"
   key "C7917B12"
 end
+package 'nodejs'


### PR DESCRIPTION
I am taking a recent version with apt_repository because the ubuntu 12.10 version is totally outdated.
