### PR TITLE
Allow Ruby 2.2.* to be installed by rbenv

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,3 +11,4 @@ apt_repository("node.js") do
   key "C7917B12"
 end
 package 'nodejs'
+package 'libffi-dev' # needed for Ruby 2.2.* to be installed by rbenv


### PR DESCRIPTION
On my testing, Ruby 2.2.* installation by rbenv fails on Digital Ocean Ubuntu 14.04 droplets.  Tracking down the error messages let me to understand that the libffi-dev package needs to be installed before Ruby 2.2.*

I noticed that in the QuickStart of the most recent version of the book, Ruby 2.2.2 is specified on page 16.  However, in the actual rails-server-template repo, Ruby 2.1.2 is specified, and changing it to Ruby 2.2.0 (or 2.2.2) failed for me.

I'm not sure that this is the best recipe for this package, but since rails_gem_dependencies-tlq cookbook runs before rbenv, making this change allowed Ruby 2.2.0 to install.