### PR TITLE
fix for the nodejs issue

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,5 @@ recipe "rails_gem_dependencies-tlq", "all the gems"
 supports "ubuntu"
 
 depends "apt"
+
+depends "nodejs"

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,7 +2,7 @@ name              "rails_gem_dependencies-tlq"
 maintainer        "Ben Dixon"
 maintainer_email  "ben@hillsbede.co.uk"
 description       "Installs packages commonly required by rails gems"
-version           "0.0.3"
+version           "0.0.4"
 
 recipe "rails_gem_dependencies-tlq", "all the gems"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,11 +3,5 @@ package 'libcurl3'
 package 'libcurl3-dev'
 package 'libmagickwand-dev'
 package 'imagemagick'
-apt_repository("node.js") do
-  uri "http://ppa.launchpad.net/chris-lea/node.js/ubuntu"
-  distribution node['lsb']['codename']
-  components ["main"]
-  keyserver "keyserver.ubuntu.com"
-  key "C7917B12"
-end
-package 'nodejs'
+include_recipe "nodejs"
+


### PR DESCRIPTION
installs `nodejs` from a cookbook instead of the existing ppa. 

Usage:

Add this to berksfile:

 `cookbook 'nodejs', '~> 5.0.0'` 

  Thats it!!!


